### PR TITLE
feat: Modernize implementation, add defer! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "defer"
 description = "Utility to defer excecution of code, inspired by go's defer statement."
-version = "0.1.0"
+version = "0.2.0"
 documentation = "https://docs.rs/defer/"
 repository = "https://github.com/andrewhickman/defer/"
 license = "MIT/Apache-2.0"
-authors = ["Andrew Hickman <andrew.hickman1@sky.com>"]
+authors = ["Andrew Hickman <andrew.hickman1@sky.com>", "Zakarum <zaq.dev@icloud.com>"]
+edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,25 @@
-struct Defer<F: FnOnce()>(Option<F>);
-
-impl<F: FnOnce()> Drop for Defer<F> {
-    fn drop(&mut self) {
-        self.0.take().map(|f| f());
-    }
-}
+use core::mem::ManuallyDrop;
 
 /// Defer execution of a closure until the return value is dropped.
-pub fn defer<F: FnOnce()>(f: F) -> impl Drop {
-    Defer(Some(f))
+pub fn defer<F>(f: F) -> impl Drop where F: FnOnce() {
+    struct Defer<F: FnOnce()>(ManuallyDrop<F>);
+    
+    impl<F: FnOnce()> Drop for Defer<F> {
+        fn drop(&mut self) {
+            let f: F = unsafe { ManuallyDrop::take(&mut self.0) };
+            f();
+        }
+    }
+    
+    Defer(ManuallyDrop::new(f))
+}
+
+/// Defer execution of a closure until the current scope end.
+#[macro_export]
+macro_rules! defer {
+    ($e:expr) => {
+        let _defer = $crate::defer(|| $e);
+    };
 }
 
 #[test]
@@ -19,6 +30,20 @@ fn test() {
 
     {
         let _d = defer(|| *i.borrow_mut() += 1);
+        assert_eq!(*i.borrow(), 0);
+    }
+
+    assert_eq!(*i.borrow(), 1);
+}
+
+#[test]
+fn test_macro() {
+    use std::cell::RefCell;
+
+    let i = RefCell::new(0);
+
+    {
+        defer!(*i.borrow_mut() += 1);
         assert_eq!(*i.borrow(), 0);
     }
 


### PR DESCRIPTION
Hi!

A little update for the crate
* Adds implementation based on ManuallyDrop
* Add defer!() macro with slightly nicer syntax
* Switch edition to 2021

Code is provided by @zakarumych, PR'd with permission. 