### PR TITLE
Make crate no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "defer"
 description = "Utility to defer excecution of code, inspired by go's defer statement."
-version = "0.2.0"
+version = "0.2.1"
 documentation = "https://docs.rs/defer/"
 repository = "https://github.com/andrewhickman/defer/"
 license = "MIT/Apache-2.0"
 authors = ["Andrew Hickman <andrew.hickman1@sky.com>", "Zakarum <zaq.dev@icloud.com>"]
 edition = "2021"
+categories = ["memory-management", "no-std", "no-std::no-alloc", "rust-patterns"]
+keywords = ["defer"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use core::mem::ManuallyDrop;
 
 /// Defer execution of a closure until the return value is dropped.
@@ -27,7 +29,7 @@ macro_rules! defer {
 
 #[test]
 fn test() {
-    use std::cell::RefCell;
+    use core::cell::RefCell;
 
     let i = RefCell::new(0);
 
@@ -41,7 +43,7 @@ fn test() {
 
 #[test]
 fn test_macro() {
-    use std::cell::RefCell;
+    use core::cell::RefCell;
 
     let i = RefCell::new(0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,11 +46,15 @@ fn test_macro() {
     use core::cell::RefCell;
 
     let i = RefCell::new(0);
+    let k = RefCell::new(0);
 
     {
         defer!(*i.borrow_mut() += 1);
+        defer!(*k.borrow_mut() += 1);
         assert_eq!(*i.borrow(), 0);
+        assert_eq!(*k.borrow(), 0);
     }
 
     assert_eq!(*i.borrow(), 1);
+    assert_eq!(*k.borrow(), 1);
 }


### PR DESCRIPTION
As @zakarumych noted this crate is perfectly no-std capable, so update it to support this.

Also add a test to confirm the macro hygiene prevents premature drop of defer binding.